### PR TITLE
Improvement: Add `HOMEBREW_BUNDLE_FILE` variable to env

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -2,6 +2,21 @@
 export NULLCMD=bat
 export DOTFILES="$HOME/.dotfiles"
 
+# We can globally specify the Brewfile location by setting the
+# `HOMEBREW_BUNDLE_FILE` environment variable. Optionally, we
+# can also use the --file command to specify the file location
+# when executing `brew bundle dump`.
+#
+# With this you can execute the `brew bundle dump` command
+# from anywhere and make sure the output always writes to the
+# same `Brewfile` location.
+#
+# With --file argument example:
+# $ brew bundle dump --force --describe --file=~/.dotfiles/brew/Brewfile`
+#
+# Reference:
+# https://docs.brew.sh/Manpage#bundle-subcommand
+export HOMEBREW_BUNDLE_FILE="$DOTFILES/Brewfile"
 
 # Change ZSH Options
 

--- a/zshrc
+++ b/zshrc
@@ -1,21 +1,6 @@
 # Set Variables
 export NULLCMD=bat
 export DOTFILES="$HOME/.dotfiles"
-
-# We can globally specify the Brewfile location by setting the
-# `HOMEBREW_BUNDLE_FILE` environment variable. Optionally, we
-# can also use the --file command to specify the file location
-# when executing `brew bundle dump`.
-#
-# With this you can execute the `brew bundle dump` command
-# from anywhere and make sure the output always writes to the
-# same `Brewfile` location.
-#
-# With --file argument example:
-# $ brew bundle dump --force --describe --file=~/.dotfiles/brew/Brewfile`
-#
-# Reference:
-# https://docs.brew.sh/Manpage#bundle-subcommand
 export HOMEBREW_BUNDLE_FILE="$DOTFILES/Brewfile"
 
 # Change ZSH Options

--- a/zshrc
+++ b/zshrc
@@ -43,6 +43,7 @@ alias trail='<<<${(F)path}'
 alias ftrail='<<<${(F)fpath}'
 alias rm=trash
 alias man=batman
+alias bbd="brew bundle dump --force --describe"
 # Load history into shell (shareHistory alternative)
 alias lh='fc -RI; echo "loaded and showing..."; history;'
 
@@ -92,11 +93,6 @@ function mkcd() {
   mkdir -p "$@" && cd "$_";
 }
 
-# Ensure Brewfile is only created in ~/.dotfiles directory
-function bbd() {
-  echo "Dumping Brewfile";
-  brew bundle dump --force --describe;
-}
 
 # Use ZSH Plugins
 ZSH_AUTOSUGGEST_STRATEGY=(history completion)

--- a/zshrc
+++ b/zshrc
@@ -94,22 +94,8 @@ function mkcd() {
 
 # Ensure Brewfile is only created in ~/.dotfiles directory
 function bbd() {
-
-  local startingDirectory=$PWD;
-
-  if [[ $startingDirectory != $DOTFILES ]]; then
-    echo "Changing to $DOTFILES";
-    cd $DOTFILES;
-  fi
-
   echo "Dumping Brewfile";
   brew bundle dump --force --describe;
-
-  if [[ $startingDirectory != $DOTFILES ]]; then
-    echo "Returning to $startingDirectory";
-    cd $startingDirectory;
-  fi
-
 }
 
 # Use ZSH Plugins


### PR DESCRIPTION
## Purpose
Refactored `bbd` function in `zshrc` file by introducing the `HOMEBREW_BUNDLE_FILE` variable to the environment. Now we don't have to issue commands to navigate into `.dotfiles` directory before executing the command `brew bundle dump`.
