### PR TITLE
Fix ls to exa alias

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -22,7 +22,7 @@ setopt globDots
 
 
 # Create Aliases
-alias ls='exa -laFh --git'
+alias ls='exa'
 alias exa='exa -laFh --git'
 alias trail='<<<${(F)path}'
 alias ftrail='<<<${(F)fpath}'


### PR DESCRIPTION
This fixes the anomoly where running `exa` doesn't show the current and parent directory, but `ls` does. As far as I can tell, this was happening as the `ls` alias was calling `exa` with the options twice — `ls` is aliased to `exa -laFh --git`, which itself calls the `exa` alias which also adds on the same options, `exa -laFh --git -laFh --git`.